### PR TITLE
메인 화면 컴포즈 구성

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <targetSelectedWithDropDown>
+    <runningDeviceTargetSelectedWithDropDown>
       <Target>
-        <type value="QUICK_BOOT_TARGET" />
+        <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
@@ -11,7 +11,7 @@
           </Key>
         </deviceKey>
       </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-09-27T05:33:51.631971Z" />
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2022-09-27T11:39:29.869971Z" />
   </component>
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,8 @@ dependencies {
     implementation(project(":di"))
     implementation(project(":domain"))
     implementation(project(":data"))
+    implementation(project(":presenter"))
+    implementation(project(":core"))
     implementation "androidx.core:core-ktx:$core_ktx_version"
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.ui:ui-tooling:$compose_version"

--- a/app/src/main/java/com/koba/bookabulary/MainActivity.kt
+++ b/app/src/main/java/com/koba/bookabulary/MainActivity.kt
@@ -3,31 +3,33 @@ package com.koba.bookabulary
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
+import androidx.activity.viewModels
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.koba.bookabulary.ui.theme.BookabularyTheme
+import com.koba.presenter.main.MainScreen
+import com.koba.presenter.main.MainViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    private val mainViewModel: MainViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContent {
             BookabularyTheme {
-                // A surface container using the 'background' color from the theme
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    Greeting("Android")
-                }
+                // // A surface container using the 'background' color from the theme
+                // Surface(
+                //     modifier = Modifier.fillMaxSize(),
+                //     color = MaterialTheme.colorScheme.background
+                // ) {
+                //     Greeting("Android")
+                // }
+                MainScreen(mainViewModel = mainViewModel)
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
         compose_compiler_version = '1.2.0'
         hilt_version = '2.42'
         kotlin_version = "1.7.0"
+        coil_compose_version = "2.2.1"
     }
 
     dependencies {

--- a/core/src/main/java/com/koba/core/base/BaseMviViewModel.kt
+++ b/core/src/main/java/com/koba/core/base/BaseMviViewModel.kt
@@ -1,5 +1,6 @@
 package com.koba.core.base
 
+import androidx.annotation.CallSuper
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.koba.core.mvi.MviEffect
@@ -22,11 +23,13 @@ abstract class BaseMviViewModel<I : MviIntent, S : MviState, E : MviEffect, SE :
     private val _effect = MutableSharedFlow<E>()
     val effect = _effect.asSharedFlow()
 
-    private inline fun updateState(function: (S) -> S) {
+    @CallSuper
+    protected fun updateState(function: (S) -> S) {
         _state.update(function)
     }
 
-    private fun emitEffect(effect: E) {
+    @CallSuper
+    protected fun emitEffect(effect: E) {
         viewModelScope.launch {
             _effect.emit(effect)
         }

--- a/domain/src/main/java/com/koba/domain/usecase/GetBestSellerUseCase.kt
+++ b/domain/src/main/java/com/koba/domain/usecase/GetBestSellerUseCase.kt
@@ -1,0 +1,13 @@
+package com.koba.domain.usecase
+
+import com.koba.domain.model.Book
+import com.koba.domain.repository.InterparkRepository
+import javax.inject.Inject
+
+class GetBestSellerUseCase @Inject constructor(
+    private val repository: InterparkRepository
+){
+    suspend operator fun invoke() : List<Book> {
+        return repository.getBestSeller()
+    }
+}

--- a/presenter/build.gradle
+++ b/presenter/build.gradle
@@ -29,6 +29,12 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    buildFeatures { // Enables Jetpack Compose for this module
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion compose_compiler_version
+    }
 }
 
 dependencies {
@@ -44,6 +50,7 @@ dependencies {
     implementation "androidx.core:core-ktx:$core_ktx_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "com.google.android.material:material:$material_version"
+    implementation "io.coil-kt:coil-compose:$coil_compose_version"
     testImplementation "junit:junit:$junit_version"
     androidTestImplementation "androidx.test.ext:junit:$test_ext_junit_version"
     androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_core_version"

--- a/presenter/build.gradle
+++ b/presenter/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'dagger.hilt.android.plugin'
+    id 'org.jetbrains.kotlin.kapt'
 }
 
 android {
@@ -30,6 +32,15 @@ android {
 }
 
 dependencies {
+    implementation(project(":domain"))
+    implementation(project(":core"))
+    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation "androidx.compose.ui:ui-tooling:$compose_version"
+    implementation "androidx.compose.material3:material3:$compose_material_version"
+    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
+    implementation "androidx.activity:activity-compose:$activity_compose_version"
+    implementation "com.google.dagger:hilt-android:$hilt_version"
+    kapt "com.google.dagger:hilt-compiler:$hilt_version"
     implementation "androidx.core:core-ktx:$core_ktx_version"
     implementation "androidx.appcompat:appcompat:$appcompat_version"
     implementation "com.google.android.material:material:$material_version"

--- a/presenter/src/main/java/com/koba/presenter/main/MainElements.kt
+++ b/presenter/src/main/java/com/koba/presenter/main/MainElements.kt
@@ -1,0 +1,28 @@
+package com.koba.presenter.main
+
+import com.koba.core.mvi.MviEffect
+import com.koba.core.mvi.MviIntent
+import com.koba.core.mvi.MviSideEffect
+import com.koba.core.mvi.MviState
+import com.koba.domain.model.Book
+
+sealed interface MainIntent : MviIntent {
+    object RequestBestSellerList : MainIntent
+
+    data class GetBestSellerListSuccess(val books: List<Book>) : MainIntent
+
+    data class GetBestSellerListFail(val throwable: Throwable) : MainIntent
+}
+
+data class MainState(
+    val isLoading: Boolean = false,
+    val bestSellers: List<Book> = emptyList()
+) : MviState
+
+sealed interface MainEffect : MviEffect {
+    data class ShowToast(val message: String) : MainEffect
+}
+
+sealed interface MainSideEffect : MviSideEffect {
+    object GetBestSellerList : MainSideEffect
+}

--- a/presenter/src/main/java/com/koba/presenter/main/MainScreen.kt
+++ b/presenter/src/main/java/com/koba/presenter/main/MainScreen.kt
@@ -101,6 +101,7 @@ fun BookItem(book: Book, onClickBook: (Book) -> Unit) {
                 model = ImageRequest.Builder(LocalContext.current)
                     .data(book.imageUrl)
                     .crossfade(true)
+                    .memoryCacheKey(book.title)
                     .build(),
                 contentScale = ContentScale.FillBounds,
                 contentDescription = book.title

--- a/presenter/src/main/java/com/koba/presenter/main/MainScreen.kt
+++ b/presenter/src/main/java/com/koba/presenter/main/MainScreen.kt
@@ -1,7 +1,88 @@
 package com.koba.presenter.main
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.koba.domain.model.Book
 
 @Composable
 fun MainScreen(mainViewModel: MainViewModel) {
+    val state = mainViewModel.state.collectAsState()
+
+    Box(
+        modifier = Modifier.fillMaxSize()
+            .padding(
+                horizontal = 10.dp
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        BestSellerGrid(books = state.value.bestSellers)
+        CircularProgress(isShow = state.value.isLoading)
+    }
+}
+
+@Composable
+fun BestSellerGrid(books: List<Book>) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(count = 3),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        items(
+            items = books
+        ) { book ->
+            BookItem(book)
+        }
+    }
+}
+
+@Composable
+fun BookItem(book: Book) {
+    Column(
+        modifier = Modifier.height(190.dp)
+    ) {
+        Card(
+            shape = RoundedCornerShape(5.dp),
+            modifier = Modifier.fillMaxSize()
+        ) {
+            AsyncImage(
+                modifier = Modifier.fillMaxSize(),
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(book.imageUrl)
+                    .crossfade(true)
+                    .build(),
+                contentScale = ContentScale.FillBounds,
+                contentDescription = book.title
+            )
+        }
+    }
+}
+
+@Composable
+fun CircularProgress(isShow: Boolean) {
+    if (isShow) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(50.dp)
+        )
+    }
 }

--- a/presenter/src/main/java/com/koba/presenter/main/MainScreen.kt
+++ b/presenter/src/main/java/com/koba/presenter/main/MainScreen.kt
@@ -1,6 +1,7 @@
 package com.koba.presenter.main
 
 import android.widget.Toast
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -54,13 +55,16 @@ fun MainScreen(mainViewModel: MainViewModel) {
             ),
         contentAlignment = Alignment.Center
     ) {
-        BestSellerGrid(books = state.value.bestSellers)
+        BestSellerGrid(books = state.value.bestSellers) {
+            // TODO move detail screen
+            Toast.makeText(context, it.title, Toast.LENGTH_SHORT).show()
+        }
         CircularProgress(isShow = state.value.isLoading)
     }
 }
 
 @Composable
-fun BestSellerGrid(books: List<Book>) {
+fun BestSellerGrid(books: List<Book>, onClickBook: (Book) -> Unit) {
     LazyVerticalGrid(
         columns = GridCells.Fixed(count = 3),
         verticalArrangement = Arrangement.spacedBy(10.dp),
@@ -69,15 +73,18 @@ fun BestSellerGrid(books: List<Book>) {
         items(
             items = books
         ) { book ->
-            BookItem(book)
+            BookItem(book, onClickBook)
         }
     }
 }
 
 @Composable
-fun BookItem(book: Book) {
+fun BookItem(book: Book, onClickBook: (Book) -> Unit) {
     Column(
         modifier = Modifier.height(190.dp)
+            .clickable {
+                onClickBook.invoke(book)
+            }
     ) {
         Card(
             shape = RoundedCornerShape(5.dp),

--- a/presenter/src/main/java/com/koba/presenter/main/MainScreen.kt
+++ b/presenter/src/main/java/com/koba/presenter/main/MainScreen.kt
@@ -1,0 +1,7 @@
+package com.koba.presenter.main
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun MainScreen(mainViewModel: MainViewModel) {
+}

--- a/presenter/src/main/java/com/koba/presenter/main/MainScreen.kt
+++ b/presenter/src/main/java/com/koba/presenter/main/MainScreen.kt
@@ -1,5 +1,6 @@
 package com.koba.presenter.main
 
+import android.content.res.Configuration
 import android.widget.Toast
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -21,6 +22,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
@@ -34,12 +36,13 @@ fun MainScreen(mainViewModel: MainViewModel) {
     val state = mainViewModel.state.collectAsState()
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
+    val isPortrait = LocalConfiguration.current.orientation == Configuration.ORIENTATION_PORTRAIT
 
     LaunchedEffect(Unit) {
         mainViewModel.effect
             .flowWithLifecycle(lifecycleOwner.lifecycle)
             .collect {
-                when(it) {
+                when (it) {
                     is MainEffect.ShowToast -> {
                         Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
                     }
@@ -55,7 +58,10 @@ fun MainScreen(mainViewModel: MainViewModel) {
             ),
         contentAlignment = Alignment.Center
     ) {
-        BestSellerGrid(books = state.value.bestSellers) {
+        BestSellerGrid(
+            books = state.value.bestSellers,
+            cellCount = if (isPortrait) 3 else 5
+        ) {
             // TODO move detail screen
             Toast.makeText(context, it.title, Toast.LENGTH_SHORT).show()
         }
@@ -64,9 +70,9 @@ fun MainScreen(mainViewModel: MainViewModel) {
 }
 
 @Composable
-fun BestSellerGrid(books: List<Book>, onClickBook: (Book) -> Unit) {
+fun BestSellerGrid(books: List<Book>, cellCount: Int, onClickBook: (Book) -> Unit) {
     LazyVerticalGrid(
-        columns = GridCells.Fixed(count = 3),
+        columns = GridCells.Fixed(cellCount),
         verticalArrangement = Arrangement.spacedBy(10.dp),
         horizontalArrangement = Arrangement.spacedBy(10.dp)
     ) {

--- a/presenter/src/main/java/com/koba/presenter/main/MainScreen.kt
+++ b/presenter/src/main/java/com/koba/presenter/main/MainScreen.kt
@@ -1,5 +1,6 @@
 package com.koba.presenter.main
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,13 +15,15 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.flowWithLifecycle
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.koba.domain.model.Book
@@ -28,9 +31,24 @@ import com.koba.domain.model.Book
 @Composable
 fun MainScreen(mainViewModel: MainViewModel) {
     val state = mainViewModel.state.collectAsState()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        mainViewModel.effect
+            .flowWithLifecycle(lifecycleOwner.lifecycle)
+            .collect {
+                when(it) {
+                    is MainEffect.ShowToast -> {
+                        Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+    }
 
     Box(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize()
             .padding(
                 horizontal = 10.dp
             ),

--- a/presenter/src/main/java/com/koba/presenter/main/MainViewModel.kt
+++ b/presenter/src/main/java/com/koba/presenter/main/MainViewModel.kt
@@ -11,6 +11,12 @@ import javax.inject.Inject
 class MainViewModel @Inject constructor(
     private val getBestSellerUseCase: GetBestSellerUseCase
 ) : BaseMviViewModel<MainIntent, MainState, MainEffect, MainSideEffect>(MainState()) {
+    init {
+        handleIntent(
+            MainIntent.RequestBestSellerList
+        )
+    }
+
     override fun handleIntent(intent: MainIntent) {
         when (intent) {
             is MainIntent.RequestBestSellerList -> {

--- a/presenter/src/main/java/com/koba/presenter/main/MainViewModel.kt
+++ b/presenter/src/main/java/com/koba/presenter/main/MainViewModel.kt
@@ -1,0 +1,17 @@
+package com.koba.presenter.main
+
+import com.koba.core.base.BaseMviViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor() : BaseMviViewModel
+<MainIntent, MainState, MainEffect, MainSideEffect>(MainState()) {
+    override fun handleIntent(intent: MainIntent) {
+        TODO("Not yet implemented")
+    }
+
+    override fun handleSideEffect(sideEffect: MainSideEffect) {
+        TODO("Not yet implemented")
+    }
+}

--- a/presenter/src/main/java/com/koba/presenter/main/MainViewModel.kt
+++ b/presenter/src/main/java/com/koba/presenter/main/MainViewModel.kt
@@ -43,6 +43,9 @@ class MainViewModel @Inject constructor(
                         isLoading = false
                     )
                 }
+                emitEffect(
+                    MainEffect.ShowToast("Fail get bestseller list, cause : ${intent.throwable.message}")
+                )
             }
         }
     }

--- a/presenter/src/main/java/com/koba/presenter/main/MainViewModel.kt
+++ b/presenter/src/main/java/com/koba/presenter/main/MainViewModel.kt
@@ -36,6 +36,9 @@ class MainViewModel @Inject constructor(
                         bestSellers = intent.books
                     )
                 }
+                emitEffect(
+                    MainEffect.ShowToast("Success get bestseller")
+                )
             }
             is MainIntent.GetBestSellerListFail -> {
                 updateState {


### PR DESCRIPTION
## Issue
#12 
## 상세 구현 설명
- 테스트를 위해 MainActivity에서 뷰모델 생성 후 MainScreen을 그리도록 작업 (추후 Compose Navigation 사용 예정)
- MainScreen이 MainViewModel를 받도록 하고 있는데 추후 테스트 용이성을 위해 state 및 고차함수(intent 발생을 위해)를 받도록 수정 예정

- ### 화면구성
![image](https://user-images.githubusercontent.com/61863078/193206897-9e146c44-2a17-46f5-93f7-bc938d4df997.png)

- 그리드를 그리기 위해  LazyVerticalGrid 사용
- 비동기로 이미지를 불러오기 위해 AsyncImage 사용
## 이 부분 중점적으로 봐주세요
- compose를 사용함에 있어 성능상 이슈가 될게 있을지 궁금합니다.

검토 부탁드립니다. 🙇
